### PR TITLE
feat: add slack notifications on failed workflows

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -9,6 +9,9 @@ on:
       cargo_registry_token:
         description: 'Cargo registry token'
         required: true
+      slack_webhook:
+        description: 'Slack webhook for notifications'
+        required: true
     inputs:
       run_tests:
         type: boolean
@@ -59,6 +62,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+
+      - name: Notify about failure
+        if: failure()
+        uses: matter-labs/format-release-please-for-slack-action@69e6fe9e4ec531b7b5fb0d826f73c190db83cf42 # v2.1.0
+        with:
+          release-please-output: '{ "body": "⚠️ Failed to publish the release" }'
+          slack-webhook-url: ${{ secrets.slack_webhook }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:


### PR DESCRIPTION
# What ❔

Add slack notifications on failed workflows.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To notify in Slack is release publishing failed.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
