### PR TITLE
fix: improve ownership change handling

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -66,11 +66,6 @@ jobs:
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 
-      - name: Install cargo workspaces
-        shell: 'bash -ex {0}'
-        if: ${{ inputs.org-owner != '' }}
-        run: cargo install cargo-workspaces
-
       - name: Build the workspace before release
         shell: 'bash -ex {0}'
         if: ${{ inputs.run_build == true || inputs.run_build == 'true' }}
@@ -83,6 +78,7 @@ jobs:
 
       - name: Run release-plz
         uses: release-plz/action@v0.5
+        id: release-plz
         with:
           command: release
           manifest_path: ${{ inputs.manifest_path }}
@@ -93,12 +89,12 @@ jobs:
 
       - name: Update ownership
         shell: 'bash -ex {0}'
-        if: ${{ inputs.org-owner != '' }}
+        if: ${{ steps.release-plz.outputs.releases_created && inputs.org-owner != '' }}
         run: |
           cd $(dirname ${{ inputs.manifest_path }})
           ORG_OWNER=${{ inputs.org-owner }}
           cargo login ${{ secrets.cargo_registry_token }}
-          for PKG in $(cargo ws list); do
+          for PKG in $(echo "${{ steps.release-plz.outputs.releases }}" | jq -r '.[].package_name'); do
             cargo owner --list --quiet ${PKG} | grep ${ORG_OWNER} || cargo owner --add ${ORG_OWNER} ${PKG}
           done
 


### PR DESCRIPTION
# What ❔

Improve ownership change handling:
* Execute ownership change only if some packages were actually released
* Update ownership only for them (also remove necessity to install `cargo workspaces` during 3 minutes)

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
