### PR TITLE
fix: add tag_name output to release-please job as well

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -111,6 +111,7 @@ jobs:
       releases: ${{ steps.release.outputs.releases }}
       prs: ${{ steps.release.outputs.prs }}
       paths_released: ${{ steps.release.outputs.paths_released }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
 
       - name: Run release-please


### PR DESCRIPTION
# What ❔

Add tag_name output to release-please job as well.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
