### PR TITLE
feat: add custom crates version suffix support

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -50,7 +50,7 @@ runs:
     - name: Install Rust toolchain
       uses: moonrepo/setup-rust@v1
       with:
-        bins: 'cargo-workspaces,cargo-get'
+        bins: 'cargo-workspaces'
 
     - name: Build the workspace before release
       shell: 'bash -ex {0}'

--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -35,11 +35,6 @@ inputs:
     type: string
     description: 'Slack webhook to use for notifications.'
     required: true
-  version-suffix:
-    type: string
-    description: 'Suffix to add to the version of the crates.'
-    required: false
-    default: ''
 
 
 runs:
@@ -73,15 +68,6 @@ runs:
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
       run: cargo login ${{ inputs.cargo_registry_token }}
-
-    - name: Add custom version suffix
-      if: ${{ inputs.version_suffix != '' }}
-      shell: 'bash -ex {0}'
-      working-directory: ${{ inputs.workspace_path }}
-      run: |
-        WORKSPACE_VERSION=$(cargo get workspace.package.version)
-        cargo workspaces version custom ${WORKSPACE_VERSION}-${{ inputs.version_suffix }} \
-          --all --no-git-commit --force "*" --yes
 
     - name: Release packages to crates.io
       shell: 'bash -ex {0}'

--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -35,6 +35,11 @@ inputs:
     type: string
     description: 'Slack webhook to use for notifications.'
     required: true
+  version-suffix:
+    type: string
+    description: 'Suffix to add to the version of the crates.'
+    required: false
+    default: ''
 
 
 runs:
@@ -50,7 +55,7 @@ runs:
     - name: Install Rust toolchain
       uses: moonrepo/setup-rust@v1
       with:
-        bins: 'cargo-workspaces'
+        bins: 'cargo-workspaces,cargo-get'
 
     - name: Build the workspace before release
       shell: 'bash -ex {0}'
@@ -68,6 +73,15 @@ runs:
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
       run: cargo login ${{ inputs.cargo_registry_token }}
+
+    - name: Add custom version suffix
+      if: ${{ inputs.version_suffix != '' }}
+      shell: 'bash -ex {0}'
+      working-directory: ${{ inputs.workspace_path }}
+      run: |
+        WORKSPACE_VERSION=$(cargo get workspace.package.version)
+        cargo workspaces version custom ${WORKSPACE_VERSION}-${{ inputs.version_suffix }} \
+          --all --no-git-commit --force "*" --yes
 
     - name: Release packages to crates.io
       shell: 'bash -ex {0}'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -162,6 +162,8 @@ jobs:
       # and take care of the proper caching to speed up CI.
       - name: Install Rust toolchain
         uses: moonrepo/setup-rust@v1
+        with:
+          bins: 'cargo-workspaces,cargo-get'
 
       - name: Update Cargo.lock
         shell: 'bash -ex {0}'
@@ -172,12 +174,28 @@ jobs:
           if [[ ${BRANCH} == *components* ]]; then
             COMPONENT="${BRANCH##*--}"
             COMPONENT_PATH=$(jq -r --arg component ${COMPONENT} '.packages | to_entries[] | select(.value.component == $component) | .key' ${{ inputs.config }})
-            ( cd "${COMPONENT_PATH}" && cargo update --workspace )
+            (
+              cd "${COMPONENT_PATH}"
+              if [[ ${{ inputs.version-suffix }} != '' ]]; then
+                WORKSPACE_VERSION=$(cargo get workspace.package.version)
+                cargo workspaces version custom ${WORKSPACE_VERSION}-${{ inputs.version-suffix }} \
+                  --all --no-git-commit --force "*" --yes
+              fi
+              cargo update --workspace
+            )
           else if [[ '${{ inputs.workspace-dirs }}' != '' ]]; then
             # In case of a one PR for multiple components
             # update Cargo.lock for all components using the workspace-dirs input.
             for WORKSPACE in ${{ inputs.workspace-dirs }} ; do
-              ( cd "${WORKSPACE}" && cargo update --workspace )
+              (
+                cd "${WORKSPACE}"
+                if [[ ${{ inputs.version-suffix }} != '' ]]; then
+                  WORKSPACE_VERSION=$(cargo get workspace.package.version)
+                  cargo workspaces version custom ${WORKSPACE_VERSION}-${{ inputs.version-suffix }} \
+                    --all --no-git-commit --force "*" --yes
+                fi
+                cargo update --workspace
+              )
             done
           fi
           # Commit changes to Cargo.lock if any

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -79,6 +79,11 @@ on:
         description: 'Commit message for Cargo.lock update.'
         required: false
         default: 'chore: update Cargo.lock'
+      version-suffix:
+        type: string
+        description: 'Suffix to add to the version of the crates.'
+        required: false
+        default: ''
     outputs:
       releases_created:
         description: "Whether release-please created a new GitHub releases."
@@ -168,7 +173,7 @@ jobs:
             COMPONENT="${BRANCH##*--}"
             COMPONENT_PATH=$(jq -r --arg component ${COMPONENT} '.packages | to_entries[] | select(.value.component == $component) | .key' ${{ inputs.config }})
             ( cd "${COMPONENT_PATH}" && cargo update --workspace )
-          else
+          else if [[ '${{ inputs.workspace-dirs }}' != '' ]]; then
             # In case of a one PR for multiple components
             # update Cargo.lock for all components using the workspace-dirs input.
             for WORKSPACE in ${{ inputs.workspace-dirs }} ; do
@@ -208,7 +213,7 @@ jobs:
       max-parallel: 1 # Publish workspaces one by one to prevent possible rate limiting issues
     steps:
       - name: Publish crates
-        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@v1
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@aba-custom-crates-suffix
         with:
           workspace_path: ${{ matrix.path }}
           org_owner: ${{ inputs.org-owner }}
@@ -217,6 +222,7 @@ jobs:
           slack_webhook: ${{ secrets.slack_webhook }}
           run_build: ${{ inputs.run_build }}
           run_tests: ${{ inputs.run_tests }}
+          version-suffix: ${{ inputs.version-suffix }}
 
 
   # This job upgrades the workspace dependencies across different workspaces of one repository.

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Install Rust toolchain
         uses: moonrepo/setup-rust@v1
         with:
-          bins: 'cargo-workspaces,cargo-get'
+          bins: 'cargo-workspaces'
 
       - name: Update Cargo.lock
         shell: 'bash -ex {0}'
@@ -174,28 +174,21 @@ jobs:
           if [[ ${BRANCH} == *components* ]]; then
             COMPONENT="${BRANCH##*--}"
             COMPONENT_PATH=$(jq -r --arg component ${COMPONENT} '.packages | to_entries[] | select(.value.component == $component) | .key' ${{ inputs.config }})
+            COMPONENT_VERSION=$(jq -r ".${COMPONENT_PATH}" ${{ inputs.manifest }})
             (
               cd "${COMPONENT_PATH}"
-              if [[ ${{ inputs.version-suffix }} != '' ]]; then
-                WORKSPACE_VERSION=$(cargo get workspace.package.version)
-                cargo workspaces version custom ${WORKSPACE_VERSION}-${{ inputs.version-suffix }} \
+              if [[ '${{ inputs.version-suffix }}' != '' ]]; then
+                cargo workspaces version custom ${COMPONENT_VERSION}-${{ inputs.version-suffix }} \
                   --all --no-git-commit --force "*" --yes
               fi
               cargo update --workspace
             )
-          else if [[ '${{ inputs.workspace-dirs }}' != '' ]]; then
+          fi
+          if [[ '${{ inputs.workspace-dirs }}' != '' ]]; then
             # In case of a one PR for multiple components
             # update Cargo.lock for all components using the workspace-dirs input.
             for WORKSPACE in ${{ inputs.workspace-dirs }} ; do
-              (
-                cd "${WORKSPACE}"
-                if [[ ${{ inputs.version-suffix }} != '' ]]; then
-                  WORKSPACE_VERSION=$(cargo get workspace.package.version)
-                  cargo workspaces version custom ${WORKSPACE_VERSION}-${{ inputs.version-suffix }} \
-                    --all --no-git-commit --force "*" --yes
-                fi
-                cargo update --workspace
-              )
+              ( cd "${WORKSPACE}" && cargo update --workspace )
             done
           fi
           # Commit changes to Cargo.lock if any
@@ -231,7 +224,7 @@ jobs:
       max-parallel: 1 # Publish workspaces one by one to prevent possible rate limiting issues
     steps:
       - name: Publish crates
-        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@aba-custom-crates-suffix
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@v1
         with:
           workspace_path: ${{ matrix.path }}
           org_owner: ${{ inputs.org-owner }}
@@ -240,7 +233,6 @@ jobs:
           slack_webhook: ${{ secrets.slack_webhook }}
           run_build: ${{ inputs.run_build }}
           run_tests: ${{ inputs.run_tests }}
-          version-suffix: ${{ inputs.version-suffix }}
 
 
   # This job upgrades the workspace dependencies across different workspaces of one repository.


### PR DESCRIPTION
# What ❔

* [x] Add custom suffix support for the workspace version.
* [x] Add capability to update `Cargo.lock` for other workspaces

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Sometimes it is required to add a suffix to the crates version. As `release-please` is unable to properly work with prereleases and support suffixes and fails to update only version part (it removes a part of the suffix with each update), the proposed solution is to update `Cargo.toml` workspace version separately just before Cargo.lock updates and commit changes together to the release PR.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
