### PR TITLE
fix: update version suffix only if not managed by release please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -178,8 +178,13 @@ jobs:
             (
               cd "${COMPONENT_PATH}"
               if [[ '${{ inputs.version-suffix }}' != '' ]]; then
-                cargo workspaces version custom ${COMPONENT_VERSION}-${{ inputs.version-suffix }} \
-                  --all --no-git-commit --force "*" --yes
+                if grep -qE '# x-release-please-version' Cargo.toml; then
+                  echo "Cargo.toml version manages through release-please. Skip the version suffix update."
+                else
+                  echo "Adding suffix to the version."
+                  cargo workspaces version custom ${COMPONENT_VERSION}-${{ inputs.version-suffix }} \
+                    --all --no-git-commit --force "*" --yes
+                fi
               fi
               cargo update --workspace
             )


### PR DESCRIPTION
# What ❔

Update version suffix only if not managed by release please.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Suffix should be updated with the version together. For components that are fully managed through `release-please`, we need to skip suffix update.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
