### PR TITLE
fix: add allow-dirty when publishing

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -72,7 +72,7 @@ runs:
     - name: Release packages to crates.io
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
-      run: cargo workspaces publish --publish-as-is
+      run: cargo workspaces publish --publish-as-is --allow-dirty
 
     - name: Update ownership
       shell: 'bash -ex {0}'


### PR DESCRIPTION
# What ❔

Add allow-dirty when publishing to crates.io.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
