### PR TITLE
chore: remove assemblycreate from foundry testing workflow

### DIFF
--- a/.github/workflows/check-foundry.yaml
+++ b/.github/workflows/check-foundry.yaml
@@ -122,4 +122,4 @@ jobs:
 
       - name: Run test foundry project
         working-directory: foundry-test-project
-        run: forge test --zksync --zk-suppressed-errors assemblycreate
+        run: forge test --zksync


### PR DESCRIPTION
# What ❔

Remove assemblycreate from foundry testing workflow.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It's a warning now.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

