### PR TITLE
fix: restore release notification

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -132,7 +132,14 @@ jobs:
           config-file: ${{ inputs.config }}
           manifest-file: ${{ inputs.manifest }}
 
-      - name: Slack notification
+      - name: Release notification
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: matter-labs/format-release-please-for-slack-action@69e6fe9e4ec531b7b5fb0d826f73c190db83cf42 # v2.1.0
+        with:
+          release-please-output: ${{ toJSON(steps.release.outputs) }}
+          slack-webhook-url: ${{ secrets.slack_webhook }}
+
+      - name: Failure notification
         if: failure()
         uses: matter-labs/zksync-ci-common/.github/actions/slack-notify-release@v1
         with:


### PR DESCRIPTION
# What ❔

Restore release notification.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

GitHub <--> Slack integration has proven to be flaky. Return the explicit notifications using `format-release-please-for-slack-action` when release is successful after fixing the webhook.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
