### PR TITLE
fix: add paths_released output to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -105,6 +105,9 @@ on:
       tag_name:
         description: "Tag name of the created release."
         value: ${{ jobs.release-please.outputs.tag_name }}
+      paths_released:
+        description: "List of paths to the released components."
+        value: ${{ jobs.release-please.outputs.paths_released }}
 
 
 jobs:


### PR DESCRIPTION
# What ❔

Add `paths_released` output to release-please workflow.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to differentiate between components in the upstream workflow.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
