### PR TITLE
fix: add all output for release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -108,6 +108,9 @@ on:
       paths_released:
         description: "List of paths to the released components."
         value: ${{ jobs.release-please.outputs.paths_released }}
+      all:
+        description: "All outputs from the release-please job."
+        value: ${{ jobs.release-please.outputs.all }}
 
 
 jobs:
@@ -125,6 +128,7 @@ jobs:
       prs: ${{ steps.release.outputs.prs }}
       paths_released: ${{ steps.release.outputs.paths_released }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      all: ${{ toJSON(steps.release.outputs) }}
     steps:
 
       - name: Run release-please


### PR DESCRIPTION
# What ❔

Add `all` output as JSON.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to access dynamic custom release-please outputs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
