### PR TITLE
fix: use default github token for PRs opening

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -135,7 +135,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.gh_token }}
+          token: ${{ github.token }}
           config-file: ${{ inputs.config }}
           manifest-file: ${{ inputs.manifest }}
 


### PR DESCRIPTION
# What ❔

Use default `GITHUB_TOKEN` for PRs opening, but input parameter (usually `bot` user private token) for Cargo updates.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To prevent unnecessary CI runs without Cargo updates and wrong merges.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Tests

Tested that tests are triggering properly in https://github.com/antonbaliasnikov/release-please-single-pr/pull/6

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
