### PR TITLE
fix: make submodules checkout optional

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -40,6 +40,11 @@ inputs:
     description: 'List of apt dependencies to install.'
     required: false
     default: ''
+  submodules:
+    type: string
+    description: 'Whether to checkout submodules.'
+    required: false
+    default: 'recursive'
 
 
 runs:
@@ -50,7 +55,7 @@ runs:
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.gh_token }}
-        submodules: "recursive"
+        submodules: "${{ inputs.submodules }}"
 
     - name: Install Rust toolchain
       uses: moonrepo/setup-rust@v1


### PR DESCRIPTION
# What ❔

Make submodules checkout optional.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Sometimes submodules checkout can not work.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
