### PR TITLE
fix: use gh_token secret when publishing to crates.io is disabled

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -135,7 +135,9 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ github.token }}
+          # If publishing to crates.io is enabled, use default github token here to not run CI twice
+          # otherwise, use the provided gh_token secret with correct permissions.
+          token: ${{ inputs.publish-to-crates-io == 'true' && github.token || secrets.gh_token }}
           config-file: ${{ inputs.config }}
           manifest-file: ${{ inputs.manifest }}
 


### PR DESCRIPTION
# What ❔

Use `gh_token` secret when publishing to crates.io is disabled.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix issues with creating tags from the default bot user and properly run CI in release PRs when crates.io publishing is disabled.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
