### PR TITLE
fix: make rust installation faster bypassing rate limiting issues

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -65,8 +65,12 @@ runs:
 
     - name: Install Rust toolchain
       uses: moonrepo/setup-rust@v1
+      env:
+        # To fix rate limiting issues with GitHub API
+        GITHUB_TOKEN: ${{ github.token }}
       with:
         bins: 'cargo-workspaces'
+        cache: false
 
     - name: Install dependencies
       if: ${{ inputs.dependencies != '' }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -180,11 +180,14 @@ jobs:
           submodules: "recursive"
 
       # It will automatically check for rust-toolchain file in the repository
-      # and take care of the proper caching to speed up CI.
       - name: Install Rust toolchain
         uses: moonrepo/setup-rust@v1
+        env:
+          # To fix rate limiting issues with GitHub API
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           bins: 'cargo-workspaces'
+          cache: false
 
       - name: Update Cargo.lock
         shell: 'bash -ex {0}'
@@ -283,11 +286,14 @@ jobs:
           submodules: "recursive"
 
       # It will automatically check for rust-toolchain file in the repository
-      # and take care of the proper caching to speed up CI.
       - name: Install Rust toolchain
         uses: moonrepo/setup-rust@v1
+        env:
+          # To fix rate limiting issues with GitHub API
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           bins: 'cargo-workspaces,cargo-edit'
+          cache: false
 
       - name: Upgrade packages
         shell: 'bash -ex {0}'


### PR DESCRIPTION
# What ❔

* [x] Make rust installation faster bypassing rate limiting issues.
* [x] Disable unnecessary Rust cache. It will require separate proper setup and cache regen from `main` later.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Related issue: https://github.com/moonrepo/setup-rust/issues/22 

Specify `GITHUB_TOKEN` as env variable to fix rate limiting issues.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
