### PR TITLE
fix: support additional cargo build args

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -22,6 +22,11 @@ inputs:
     description: 'Whether to run build before release.'
     required: false
     default: 'true'
+  cargo_build_args:
+    type: string
+    description: 'Additional arguments to pass to cargo during the build.'
+    required: false
+    default: ''
   run_tests:
     type: string
     description: 'Whether to run tests before release.'
@@ -82,13 +87,13 @@ runs:
       shell: 'bash -ex {0}'
       if: ${{ inputs.run_build == true || inputs.run_build == 'true' }}
       working-directory: ${{ inputs.workspace_path }}
-      run: cargo build && cargo clean
+      run: cargo build ${{ inputs.cargo_build_args }} && cargo clean
 
     - name: Run tests before release
       shell: 'bash -ex {0}'
       if: ${{ inputs.run_tests == true || inputs.run_tests == 'true' }}
       working-directory: ${{ inputs.workspace_path }}
-      run: cargo test && cargo clean
+      run: cargo test ${{ inputs.cargo_build_args }} && cargo clean
 
     - name: Login to registry
       shell: 'bash -ex {0}'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -34,6 +34,11 @@ on:
         description: 'Build the workspace before release'
         required: false
         default: true
+      cargo_build_args:
+        type: string
+        description: 'Additional arguments to pass to cargo during the build'
+        required: false
+        default: ''
       run_tests:
         type: boolean
         description: 'Run tests before release'
@@ -263,6 +268,7 @@ jobs:
           cargo_registry_token: ${{ secrets.cargo_registry_token }}
           slack_webhook: ${{ secrets.slack_webhook }}
           run_build: ${{ inputs.run_build }}
+          cargo_build_args: ${{ inputs.cargo_build_args }}
           run_tests: ${{ inputs.run_tests }}
           dependencies: ${{ inputs.dependencies }}
 


### PR DESCRIPTION
# What ❔

Support additional cargo build args.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

For some projects, it can be required to pass additional build arguments for cargo commands.
For example, `vm2` requires disabling of fuzzer.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
