### PR TITLE
fix: always use secret gh_token for release please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -140,9 +140,9 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # If publishing to crates.io is enabled, use default github token here to not run CI twice
-          # otherwise, use the provided gh_token secret with correct permissions.
-          token: ${{ inputs.publish-to-crates-io == 'true' && github.token || secrets.gh_token }}
+          # Always use gh_token to trigger workflows after tag publishing
+          # DO NOT use default github_token here (!)
+          token: ${{ secrets.gh_token }}
           config-file: ${{ inputs.config }}
           manifest-file: ${{ inputs.manifest }}
 


### PR DESCRIPTION
# What ❔

* [x] always use secret gh_token for release please

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To always trigger next CI runs for the published token.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
