### PR TITLE
chore: remove deprecated --no-commit flag from forge init

### DIFF
--- a/.github/workflows/check-foundry.yaml
+++ b/.github/workflows/check-foundry.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          forge init --no-git --no-commit foundry-test-project
+          forge init --no-git foundry-test-project
 
       - name: Patch solc version
         if: inputs.solidity-version != ''


### PR DESCRIPTION
# What ❔

Remove deprecated --no-commit flag from forge init.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

The most recent `forge` version removed `--no-commit` flag.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
