### PR TITLE
fix: use --exact when updating versions in Cargo.toml

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -207,7 +207,7 @@ jobs:
             (
               cd "${COMPONENT_PATH}"
               cargo workspaces version custom ${COMPONENT_VERSION} \
-                --all --no-git-commit --force "*" --yes
+                --all --exact --no-git-commit --force "*" --yes
               if [[ '${{ inputs.version-suffix }}' != '' ]]; then
                 if grep -qE '# x-release-please-version' Cargo.toml; then
                   echo "Cargo.toml version manages through release-please. Skip the version suffix update."


### PR DESCRIPTION
# What ❔

Use --exact when updating versions in Cargo.toml.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To properly update Cargo files and pin versions.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
