### PR TITLE
chore: add --locked for build and test during publishing

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -87,13 +87,13 @@ runs:
       shell: 'bash -ex {0}'
       if: ${{ inputs.run_build == true || inputs.run_build == 'true' }}
       working-directory: ${{ inputs.workspace_path }}
-      run: cargo build ${{ inputs.cargo_build_args }} && cargo clean
+      run: cargo build --locked ${{ inputs.cargo_build_args }} && cargo clean
 
     - name: Run tests before release
       shell: 'bash -ex {0}'
       if: ${{ inputs.run_tests == true || inputs.run_tests == 'true' }}
       working-directory: ${{ inputs.workspace_path }}
-      run: cargo test ${{ inputs.cargo_build_args }} && cargo clean
+      run: cargo test --locked ${{ inputs.cargo_build_args }} && cargo clean
 
     - name: Login to registry
       shell: 'bash -ex {0}'


### PR DESCRIPTION
# What ❔

Add `--locked` for build and test during publishing to crates.io.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To not update Cargo.lock file before running `cargo workspace publish`.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
