### PR TITLE
feat: add dry publishing check making --locked optional

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -55,6 +55,16 @@ inputs:
     description: 'Whether to skip checkout.'
     required: false
     default: 'false'
+  locked:
+    type: string
+    description: 'Whether to use --locked option for cargo commands.'
+    required: false
+    default: 'false'
+  dry_run:
+    type: string
+    description: 'Whether to run the publishing in dry mode.'
+    required: false
+    default: 'false'
 
 
 runs:
@@ -92,6 +102,7 @@ runs:
       run: sudo apt update && sudo apt install --yes ${{ inputs.dependencies }}
 
     - name: Check for Cargo.lock file
+      if: ${{ inputs.locked == 'true' }}
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
       id: cargo-lock
@@ -123,11 +134,12 @@ runs:
       working-directory: ${{ inputs.workspace_path }}
       run: |
         cargo workspaces --version
-        cargo workspaces publish ${{ steps.cargo-lock.outputs.locked }} --publish-as-is --allow-dirty
+        [[ ${{ inputs.dry_run }} == 'true' ]] && DRY_RUN="--dry-run"
+        cargo workspaces publish ${{ steps.cargo-lock.outputs.locked }} ${DRY_RUN} --publish-as-is --allow-dirty
 
     - name: Update ownership
       shell: 'bash -ex {0}'
-      if: success() && inputs.org-owner != ''
+      if: success() && inputs.org-owner != '' && inputs.dry_run == 'false'
       working-directory: ${{ inputs.workspace_path }}
       run: |
         # Fail on error from pipe commands


### PR DESCRIPTION
# What ❔

* [x] Add dry publishing
* [x] Make `--locked` publishing optional and `false` by default 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

We experience issues with `--locked` publishing when we have circular `dev-dependencies` that impact Cargo.lock preventing successful publishing.
We prefer to make `--locked` optional and `false` by default introducing `--dry-run` that will allow us to test the publishing in release PR before merging it to be 100% all is correct and minor changes in packages that can be taken by `cargo publish` in 3rd party crates will not be breaking.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
