### PR TITLE
chore: add notify_slack option to publish crates

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -65,6 +65,11 @@ inputs:
     description: 'Whether to run the publishing in dry mode.'
     required: false
     default: 'false'
+  notify_slack:
+    type: string
+    description: 'Whether to notify Slack on failure.'
+    required: false
+    default: 'true'
 
 
 runs:
@@ -150,7 +155,7 @@ runs:
         done
 
     - name: Slack notification
-      if: failure()
+      if: failure() && inputs.notify_slack == 'true'
       uses: matter-labs/zksync-ci-common/.github/actions/slack-notify-release@v1
       with:
         webhook: ${{ inputs.slack_webhook }}


### PR DESCRIPTION
# What ❔

Add `notify_slack` option to publish crates.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow disabling of Slack notifications for particular use cases.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
