### PR TITLE
fix: when using version suffix, add --exact

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -214,7 +214,7 @@ jobs:
                 else
                   echo "Adding suffix to the version."
                   cargo workspaces version custom ${COMPONENT_VERSION}-${{ inputs.version-suffix }} \
-                    --all --no-git-commit --force "*" --yes
+                    --all --no-git-commit --force --exact "*" --yes
                 fi
               fi
               cargo update --workspace


### PR DESCRIPTION
# What ❔

When using version suffix, add `--exact` option.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
