### PR TITLE
fix: use https xoauth for private cargo repositories

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -194,6 +194,17 @@ jobs:
           bins: 'cargo-workspaces'
           cache: false
 
+      - name: Git config for private repositories
+        env:
+          GH_TOKEN: ${{ secrets.gh_token }}
+        shell: 'bash -ex {0}'
+        run: |
+          IS_REPO_PRIVATE=$(gh api repos/${{ github.repository }} --jq '.private')
+          if [[ "${IS_REPO_PRIVATE}" == "true" ]]; then
+            echo CARGO_NET_GIT_FETCH_WITH_CLI=true >> "${GITHUB_ENV}"
+            git config --global url."https://${{ secrets.gh_token }}:x-oauth-basic@github.com/".insteadOf "ssh://git@github.com/"
+          fi
+
       - name: Update Cargo.lock
         shell: 'bash -ex {0}'
         run: |


### PR DESCRIPTION
# What ❔

Use https xoauth for private cargo repositories.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To properly update Cargo files in repositories with private git dependencies.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
