### PR TITLE
feat: add reusable SBOM workflow

### DIFF
--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,0 +1,102 @@
+name: SBOM generation and upload to Dependency Track
+
+on:
+  workflow_call:
+    inputs:
+      dtrack_server_hostname:
+        description: Hostname of the Dependency Track
+        required: true
+        type: string
+      git_version:
+        description: Commit hash/tag to run SBOM generation against
+        required: true
+        type: string
+      ghcr_registry_username:
+        description: GHCR registry username, used to pull freshly generated images for scanning
+        required: true
+        type: string
+      containers:
+        description: JSON array of {name, tag} objects for containers to run SBOM generation against, e.g. '[{"name":"app1","tag":"v1.0.0"},{"name":"app2","tag":"v2.3.1"}]'
+        required: true
+        type: string
+      dt_project_tags:
+        description: Tags to put on created Dependency Track projects
+        required: true
+        type: string
+
+    secrets:
+      dtrack_api_key:
+        description: API Keys for uploading SBOMs and creating projects in Dependency Track
+        required: true
+      ghcr_registry_password:
+        description: GHCR registry password, used to pull freshly generated images for scanning
+        required: true
+
+
+jobs:
+  sbom-code:
+    name: Generate and upload SBOM of the source code for analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.git_version }}
+
+      - name: Generate CycloneDX file on code analysis
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          output-file: "bom-code.cdx.json"
+          format: 'cyclonedx-json@1.6'
+          upload-artifact: 'false'
+          upload-release-assets: 'false'
+
+      - name: Upload CycloneDX file to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@b717d6595efa77a7ff1b18b57ac28597afc75d77 # v4.0.0
+        with:
+          serverhostname: ${{ inputs.dtrack_server_hostname }}
+          apikey: ${{ secrets.dtrack_api_key }}
+          projectname: "${{ github.event.repository.name }}-code"
+          projectversion: ${{ inputs.git_version }}
+          isLatest: true
+          bomfilename: "bom-code.cdx.json"
+          autocreate: true
+          projecttags: ${{ inputs.dt_project_tags }}
+
+  sbom-image:
+    name: Generate and upload SBOM of the container images for analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      matrix:
+        container: ${{ fromJSON(inputs.containers) }}
+    steps:
+      - run: echo "${{ matrix.container.name }}:${{ matrix.container.tag }}"
+
+      - name: Generate CycloneDX file on image analysis
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/matter-labs/${{ matrix.container.name }}:${{ matrix.container.tag }}
+          registry-username: ${{ inputs.ghcr_registry_username }}
+          registry-password: ${{ secrets.ghcr_registry_password }}
+          output-file: "bom-${{ matrix.container.name }}-image.cdx.json"
+          format: 'cyclonedx-json@1.6'
+          upload-artifact: 'false'
+          upload-release-assets: 'false'
+
+      - name: Upload CycloneDX file to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@b717d6595efa77a7ff1b18b57ac28597afc75d77 # v4.0.0
+        with:
+          serverhostname: ${{ inputs.dtrack_server_hostname }}
+          apikey: ${{ secrets.dtrack_api_key }}
+          projectname: "${{ matrix.container.name }}-image"
+          projectversion: ${{ matrix.container.tag }}
+          isLatest: true
+          bomfilename: "bom-${{ matrix.container.name }}-image.cdx.json"
+          autocreate: true
+          projecttags: ${{ inputs.dt_project_tags }}

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       containers:
-        description: JSON array of {name, tag} objects for containers to run SBOM generation against, e.g. '[{"name":"app1","tag":"v1.0.0"},{"name":"app2","tag":"v2.3.1"}]'
+        description: Comma-separated list of container name:tag pairs to run SBOM generation against, e.g. 'app1:v1.0.0,app2:v2.3.1'
         required: true
         type: string
       dt_project_tags:
@@ -34,6 +34,20 @@ on:
 
 
 jobs:
+  prepare-matrix:
+    name: Parse containers input into a JSON array
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Convert containers list to JSON array
+        id: set-matrix
+        env:
+          CONTAINERS_INPUT: ${{ inputs.containers }}
+        run: |
+          matrix=$(jq -R -c 'split(",") | map(gsub("^\\s+|\\s+$";"") | split(":") | {name: .[0], tag: .[1]})' <<< "$CONTAINERS_INPUT")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   sbom-code:
     name: Generate and upload SBOM of the source code for analysis
     runs-on: ubuntu-latest
@@ -68,16 +82,15 @@ jobs:
 
   sbom-image:
     name: Generate and upload SBOM of the container images for analysis
+    needs: prepare-matrix
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
     strategy:
       matrix:
-        container: ${{ fromJSON(inputs.containers) }}
+        container: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
     steps:
-      - run: echo "${{ matrix.container.name }}:${{ matrix.container.tag }}"
-
       - name: Generate CycloneDX file on image analysis
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:


### PR DESCRIPTION
# What ❔

Adds the shared `sbom-analysis-reusable.yaml` workflow to this repo, so we generate CycloneDX SBOMs for both the source code and our container images and upload them to Dependency Track.                                                                                                                         
                                                                                                                                                                                
Containers to scan are passed as one comma-separated string, e.g. `app1:v1.0.0,app2:v2.3.1`. A small `prepare-matrix` job turns that into a matrix so each image gets scanned separately.   

## Why ❔

The SBOM workflows that were added to individual repositories so far look almost the same, this PR adds the shared workflow instead of copy-pasting the scan/upload steps to each repository.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
