### PR TITLE
feat(publish-crates): switch to trusted publishing with short-lived tokens, remove "Update ownership" step and pin action versions to hashes

### DIFF
--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -129,18 +129,18 @@ runs:
       working-directory: ${{ inputs.workspace_path }}
       run: cargo test ${{ steps.cargo-lock.outputs.locked }} ${{ inputs.cargo_build_args }} && cargo clean
 
-    - name: Login to registry
-      shell: 'bash -ex {0}'
-      working-directory: ${{ inputs.workspace_path }}
-      env:
-        CARGO_REGISTRIES_STAGING_INDEX: sparse+https://index.staging.crates.io/
-      run: cargo login --registry staging ${{ inputs.cargo_registry_token }}
+    - name: Authenticate with custom registry
+      id: auth
+      uses: rust-lang/crates-io-auth-action@v1
+      with:
+        url: https://staging.crates.io
 
     - name: Release packages to staging.crates.io
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
       env:
         CARGO_REGISTRIES_STAGING_INDEX: sparse+https://index.staging.crates.io/
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       run: |
         cargo workspaces --version
         [[ ${{ inputs.dry_run }} == 'true' ]] && DRY_RUN="--dry-run"

--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -132,15 +132,19 @@ runs:
     - name: Login to registry
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
-      run: cargo login ${{ inputs.cargo_registry_token }}
+      env:
+        CARGO_REGISTRIES_STAGING_INDEX: sparse+https://index.staging.crates.io/
+      run: cargo login --registry staging ${{ inputs.cargo_registry_token }}
 
-    - name: Release packages to crates.io
+    - name: Release packages to staging.crates.io
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
+      env:
+        CARGO_REGISTRIES_STAGING_INDEX: sparse+https://index.staging.crates.io/
       run: |
         cargo workspaces --version
         [[ ${{ inputs.dry_run }} == 'true' ]] && DRY_RUN="--dry-run"
-        cargo workspaces publish ${{ steps.cargo-lock.outputs.locked }} ${DRY_RUN} --publish-as-is --allow-dirty
+        cargo workspaces publish ${{ steps.cargo-lock.outputs.locked }} ${DRY_RUN} --publish-as-is --allow-dirty --registry staging
 
     - name: Update ownership
       shell: 'bash -ex {0}'

--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -140,7 +140,7 @@ runs:
       working-directory: ${{ inputs.workspace_path }}
       env:
         CARGO_REGISTRIES_STAGING_INDEX: sparse+https://index.staging.crates.io/
-        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        CARGO_REGISTRIES_STAGING_TOKEN: ${{ steps.auth.outputs.token }}
       run: |
         cargo workspaces --version
         [[ ${{ inputs.dry_run }} == 'true' ]] && DRY_RUN="--dry-run"

--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -69,7 +69,7 @@ runs:
 
     - name: Checkout repository
       if: ${{ inputs.skip_checkout != 'true' }}
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7
       with:
         token: ${{ inputs.gh_token }}
         submodules: "${{ inputs.submodules }}"

--- a/.github/actions/publish-crates/action.yaml
+++ b/.github/actions/publish-crates/action.yaml
@@ -8,11 +8,6 @@ inputs:
     description: 'Path to the workspace to publish.'
     default: '.'
     required: false
-  org_owner:
-    type: string
-    description: 'Organization to add as owner of the crates.'
-    required: false
-    default: 'github:matter-labs:crates-io'
   gh_token:
     type: string
     description: 'GitHub token to use for checking out the repository.'
@@ -32,10 +27,6 @@ inputs:
     description: 'Whether to run tests before release.'
     required: false
     default: 'false'
-  cargo_registry_token:
-    type: string
-    description: 'Token to use for publishing to crates.io.'
-    required: true
   slack_webhook:
     type: string
     description: 'Slack webhook to use for notifications.'
@@ -78,13 +69,13 @@ runs:
 
     - name: Checkout repository
       if: ${{ inputs.skip_checkout != 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v4
       with:
         token: ${{ inputs.gh_token }}
         submodules: "${{ inputs.submodules }}"
 
     - name: Install Rust toolchain
-      uses: moonrepo/setup-rust@v1
+      uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # moonrepo/setup-rust@v1
       env:
         # To fix rate limiting issues with GitHub API
         GITHUB_TOKEN: ${{ github.token }}
@@ -129,38 +120,23 @@ runs:
       working-directory: ${{ inputs.workspace_path }}
       run: cargo test ${{ steps.cargo-lock.outputs.locked }} ${{ inputs.cargo_build_args }} && cargo clean
 
-    - name: Authenticate with custom registry
+    - name: Authenticate into crates.io
       id: auth
-      uses: rust-lang/crates-io-auth-action@v1
-      with:
-        url: https://staging.crates.io
+      uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # rust-lang/crates-io-auth-action@v1
 
-    - name: Release packages to staging.crates.io
+    - name: Release packages to crates.io
       shell: 'bash -ex {0}'
       working-directory: ${{ inputs.workspace_path }}
       env:
-        CARGO_REGISTRIES_STAGING_INDEX: sparse+https://index.staging.crates.io/
-        CARGO_REGISTRIES_STAGING_TOKEN: ${{ steps.auth.outputs.token }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       run: |
         cargo workspaces --version
         [[ ${{ inputs.dry_run }} == 'true' ]] && DRY_RUN="--dry-run"
-        cargo workspaces publish ${{ steps.cargo-lock.outputs.locked }} ${DRY_RUN} --publish-as-is --allow-dirty --registry staging
-
-    - name: Update ownership
-      shell: 'bash -ex {0}'
-      if: success() && inputs.org-owner != '' && inputs.dry_run == 'false'
-      working-directory: ${{ inputs.workspace_path }}
-      run: |
-        # Fail on error from pipe commands
-        set -o pipefail
-        ORG_OWNER=${{ inputs.org-owner }}
-        for PKG in $(cargo ws list); do
-          cargo owner --list --quiet ${PKG} | grep ${ORG_OWNER} || cargo owner --add ${ORG_OWNER} ${PKG}
-        done
+        cargo workspaces publish ${{ steps.cargo-lock.outputs.locked }} ${DRY_RUN} --publish-as-is --allow-dirty
 
     - name: Slack notification
       if: failure() && inputs.notify_slack == 'true'
-      uses: matter-labs/zksync-ci-common/.github/actions/slack-notify-release@v1
+      uses: matter-labs/zksync-ci-common/.github/actions/slack-notify-release@0a6a75b4b9710cc51af2207e81a0a4df98bc8a5b # matter-labs/zksync-ci-common/.github/actions/slack-notify-release@v1
       with:
         webhook: ${{ inputs.slack_webhook }}
         context: 'Unable to publish to crates.io'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,9 +14,6 @@ on:
       gh_token:
         description: 'GitHub token'
         required: true
-      cargo_registry_token:
-        description: 'Cargo registry token'
-        required: false
       slack_webhook:
         description: 'Slack webhook for notifications'
         required: false
@@ -64,11 +61,6 @@ on:
         description: 'Whether to upgrade dependencies'
         required: false
         default: 'false'
-      org-owner:
-        type: string
-        description: 'Organization to add as owner of the crates.'
-        required: false
-        default: 'github:matter-labs:crates-io'
       git-user-name:
         type: string
         description: 'Name of the user to use for git operations.'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -277,12 +277,10 @@ jobs:
       max-parallel: 1 # Publish workspaces one by one to prevent possible rate limiting issues
     steps:
       - name: Publish crates
-        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@v1
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@main # will be updated to commit hash with another PR
         with:
           workspace_path: ${{ matrix.path }}
-          org_owner: ${{ inputs.org-owner }}
           gh_token: ${{ secrets.gh_token }}
-          cargo_registry_token: ${{ secrets.cargo_registry_token }}
           slack_webhook: ${{ secrets.slack_webhook }}
           run_build: ${{ inputs.run_build }}
           cargo_build_args: ${{ inputs.cargo_build_args }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -269,6 +269,9 @@ jobs:
     needs: release-please
     name: Publish to crates.io
     runs-on: matterlabs-ci-runner-highdisk
+    permissions:
+      contents: read
+      id-token: write
     if: ${{ needs.release-please.outputs.releases_created == 'true' && inputs.publish-to-crates-io == 'true' }}
     strategy:
       matrix:


### PR DESCRIPTION
# What ❔

- switch from static crates.io API tokens to trusted publishing
- remove "Update ownership" step from the pipeline 
- pin hashes of action versions

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
