### PR TITLE
fix(publish-crates): set a commit hash as version of publish-crates action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -272,7 +272,7 @@ jobs:
       max-parallel: 1 # Publish workspaces one by one to prevent possible rate limiting issues
     steps:
       - name: Publish crates
-        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@main # will be updated to commit hash with another PR
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@c488e5a187bfa5b667ec31061045be3ad7f3245a # main
         with:
           workspace_path: ${{ matrix.path }}
           gh_token: ${{ secrets.gh_token }}


### PR DESCRIPTION
# What ❔

- pin version of the publish-crates action to a commit hash in release-please workflow

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
